### PR TITLE
Better config check.

### DIFF
--- a/easydate.js
+++ b/easydate.js
@@ -15,7 +15,7 @@ function easydate (pattern, config) {
   var time = config && config.timeZone ? config.timeZone : 'local'
   var adjust = config ? config.adjust : false
   var date
-  if (config && 'setDate' in config && !setDate) return null
+  if (typeof config === 'object' && config.hasOwnProperty('setDate')) return null
   function tidyNumber (value) {
     if (value < 10) return '0' + String(value)
     return String(value)

--- a/easydate.js
+++ b/easydate.js
@@ -15,7 +15,7 @@ function easydate (pattern, config) {
   var time = config && config.timeZone ? config.timeZone : 'local'
   var adjust = config ? config.adjust : false
   var date
-  if (typeof config === 'object' && config.hasOwnProperty('setDate')) return null
+  if (typeof config === 'object' && config.hasOwnProperty('setDate') && !setDate) return null
   function tidyNumber (value) {
     if (value < 10) return '0' + String(value)
     return String(value)


### PR DESCRIPTION
Or it will bomb for:

```js
> easydate('d-M-Y @ h:m', '2015-11-03T16:06:00.000Z')
TypeError: Cannot use 'in' operator to search for 'setDate' in 2015-11-03T16:06:00.000Z
```